### PR TITLE
Kops 1.8

### DIFF
--- a/aws/cluster/networking.tf
+++ b/aws/cluster/networking.tf
@@ -13,6 +13,10 @@ resource "aws_vpc" "main" {
     Name   = "${var.cluster-name}"
     Origin = "Terraform"
   }
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 // Internet Gateway

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -134,8 +134,8 @@ variable "channel" {
 
 variable "kubernetes-version" {
   type        = "string"
-  description = "Kubernetes version to use for Core components (default: v1.7.4)"
-  default     = "v1.7.4"
+  description = "Kubernetes version to use for Core components (default: v1.8.4)"
+  default     = "v1.8.4"
 }
 
 variable "cloud-labels" {

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -209,7 +209,7 @@ variable "master-machine-type" {
   type        = "string"
   description = "EC2 instance type to run our masters onto (default: m3.medium)"
 
-  default = "m3.medium"
+  default = "c4.large"
 }
 
 variable "master-volume-size" {

--- a/aws/ig/main.tf
+++ b/aws/ig/main.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket_object" "ig-spec" {
   // On destroy, remove the IG, if it exists
   provisioner "local-exec" {
     when    = "destroy"
-    command = "(test -z \"$(kops get cluster | grep ${var.cluster-name})\" ) || kops --state=s3://${var.kops-state-bucket} delete ig --name ${var.cluster-name} --yes ${var.name}"
+    command = "(test -z \"$(kops --state=s3://${var.kops-state-bucket} get cluster | grep ${var.cluster-name})\" ) || kops --state=s3://${var.kops-state-bucket} delete ig --name ${var.cluster-name} --yes ${var.name}"
   }
 }
 

--- a/aws/test/data.tf
+++ b/aws/test/data.tf
@@ -1,0 +1,44 @@
+# AWS account information
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "main" {
+  current = true
+}
+
+# CoreOS base AMI
+variable "coreos-ami-owner-id" {
+  description = "The ID of the owner of the CoreOS image you want to use on the AWS marketplace (or yours if you're using your own AMI)."
+
+  # CoreOS' official AWS id
+  default = "595879546273"
+  type    = "string"
+}
+
+variable "coreos-ami-pattern" {
+  description = "The AMI pattern to use (it can be a full name or contain wildcards, default to the last release of CoreOS on the stable channel)."
+
+  # Useful to change that to also run tests against the beta and alpha version of Container Linux
+  default = "CoreOS-stable-*"
+  type    = "string"
+}
+
+data "aws_ami" "coreos-stable" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["${var.coreos-ami-pattern}"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["${var.coreos-ami-owner-id}"]
+}
+
+data "aws_route53_zone" "test" {
+  name         = "${var.domain}"
+  private_zone = "false"
+}

--- a/aws/test/dns.tf
+++ b/aws/test/dns.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "pong" {
+  zone_id = "${data.aws_route53_zone.test.id}"
+  name    = "pong"
+  type    = "A"
+
+  alias {
+    name                   = "${module.test-cluster.ingress-elb-dns-name}"
+    zone_id                = "${module.test-cluster.ingress-elb-zone-id}"
+    evaluate_target_health = "false"
+  }
+}

--- a/aws/test/iam-kops.tf
+++ b/aws/test/iam-kops.tf
@@ -1,0 +1,26 @@
+/*
+ * IAM policies for kops are defined here, according to the "kops-policies" variable
+ */
+
+# Kops
+resource "aws_iam_group" "kops" {
+  name = "kops-test"
+  path = "/"
+}
+
+resource "aws_iam_group_policy_attachment" "kops" {
+  count      = "${length(var.kops-policies)}"
+  group      = "${aws_iam_group.kops.name}"
+  policy_arn = "arn:aws:iam::aws:policy/${element(var.kops-policies, count.index)}"
+}
+
+resource "aws_iam_group_membership" "kops" {
+  name  = "kops-membership"
+  group = "${aws_iam_group.kops.name}"
+  users = ["${aws_iam_user.kops.name}"]
+}
+
+resource "aws_iam_user" "kops" {
+  name = "kops-test"
+  path = "/"
+}

--- a/aws/test/k8s/backend/pong.yaml
+++ b/aws/test/k8s/backend/pong.yaml
@@ -1,0 +1,82 @@
+# Just an example service to confirm that requests are routed to pods
+# accordingly
+apiVersion: v1
+kind: Service
+metadata:
+  name: pong
+  labels:
+    app: pong
+spec:
+  selector:
+    app: pong
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000
+    name: http
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pong
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+  - secretName: tls-pong
+    hosts:
+    - pong.${domain}
+  rules:
+  - host: pong.${domain}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: pong
+          servicePort: http
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: pong
+  labels:
+    app: pong
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: pong
+  template:
+    metadata:
+      labels:
+        app: pong
+    spec:
+      nodeSelector:
+        duty: webserver
+      containers:
+      - image: elafarge/http-logger
+        name: http-logger
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 10m
+            memory: 10Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            port: 8000
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            port: 8000
+        args:
+        - -listen
+        - ":8000"
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP

--- a/aws/test/k8s/backend/pong.yaml
+++ b/aws/test/k8s/backend/pong.yaml
@@ -42,7 +42,7 @@ metadata:
   labels:
     app: pong
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 1
   selector:
     matchLabels:
@@ -52,6 +52,7 @@ spec:
       labels:
         app: pong
     spec:
+      terminationGracePeriodSeconds: 10
       nodeSelector:
         duty: webserver
       containers:
@@ -80,3 +81,18 @@ spec:
         - name: http
           containerPort: 8000
           protocol: TCP
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values: ["pong"]
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values: ["pong"]
+            topologyKey: failure-domain.beta.kubernetes.io/zone

--- a/aws/test/k8s/ingress/default-backend.yaml
+++ b/aws/test/k8s/ingress/default-backend.yaml
@@ -1,0 +1,101 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: default-backend
+  namespace: ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+    app: default-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    app: default-backend
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: default-backend
+  namespace: ingress
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: default-backend
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: default-backend
+  namespace: ingress
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: default-backend
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-backend
+  namespace: ingress
+  labels:
+    k8s-app: default-http-backend
+    k8s-addon: ingress-nginx.addons.k8s.io
+    app: default-backend
+spec:
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app: default-backend
+    spec:
+      nodeSelector:
+        duty: intake
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+      restartPolicy: Always
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values: ["default-backend"]
+              topologyKey: kubernetes.io/hostname
+          - weight: 50
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values: ["default-backend"]
+              topologyKey: failure-domain.beta.kubernetes.io/zone

--- a/aws/test/k8s/ingress/kube-lego.yaml
+++ b/aws/test/k8s/ingress/kube-lego.yaml
@@ -1,0 +1,99 @@
+# Note: kube-lego fetches certificates from Let's Encrypt for you ingress
+# domains automatically... however, we wouldn't recommend using it for
+# production-critical workloads, unless you really don't want to pay for a
+# wildcard certificate...
+# ---
+
+# ServiceAccount and Roles
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-lego
+  namespace: ingress
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-lego
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-lego
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-lego
+subjects:
+  - kind: ServiceAccount
+    name: kube-lego
+    namespace: ingress
+---
+
+# The actual lego deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-lego
+  namespace: ingress
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-lego
+    spec:
+      serviceAccountName: kube-lego
+      nodeSelector:
+        duty: intake
+      containers:
+      - name: kube-lego
+        image: jetstack/kube-lego:canary
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: LEGO_EMAIL
+          value: "karch-tests-01@mailinator.com"
+        - name: LEGO_URL
+          value: "https://acme-v01.api.letsencrypt.org/directory"
+        - name: LEGO_NAMESPACE
+          value: ingress
+        - name: LEGO_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1

--- a/aws/test/k8s/ingress/nginx-ingress-controller.yaml
+++ b/aws/test/k8s/ingress/nginx-ingress-controller.yaml
@@ -1,0 +1,319 @@
+# ServiceAccount for our Ingress controller
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:ingress:nginx-ingress-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  # Defaults to "<election-id>-<ingress-class>"
+  # Here: "<ingress-controller-leader>-<nginx>"
+  # This has to be adapted if you change either parameter
+  # when launching the nginx-ingress-controller.
+  - "ingress-controller-leader-nginx"
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-addon: ingress-nginx.addons.k8s.io
+  name: nginx-ingress-controller
+  namespace: ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-controller
+  namespace: ingress
+---
+
+# Ingress Controller config
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress
+data:
+  proxy-body-size: "0"
+  enable-vts-status: "false"
+  gzip-types: "*"
+  keep-alive: "5"
+  hsts: "true"
+  hsts-max-age: "100000"
+  hsts-include-subdomains: "false"
+  log-format-upstream: '{ "time": "$time_iso8601", "remote_addr": "$proxy_protocol_addr", "x-forward-for": "$proxy_add_x_forwarded_for", "request_id": "$request_id", "remote_user": "$remote_user", "bytes_sent": $bytes_sent, "request_time": $request_time, "status": $status, "vhost": "$host", "request_proto": "$server_protocol", "path": "$uri", "request_query": "$args", "request_length": $request_length, "duration": $request_time, "method": "$request_method", "http_referrer": "$http_referer", "http_user_agent": "$http_user_agent" }'
+  max-worker-connections: "10000"
+  proxy-connect-timeout: "5"
+  proxy-read-timeout: "600"
+  proxy-send-timeout: "60"
+  retry-non-idempotent: "false"
+  proxy-request-buffering: "on"
+  ssl-ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
+  # ssl-dh-param: TODO: set this to enable perfect forward secrecy
+  server-name-hash-bucket-size: "256"
+  ssl-protocols: "TLSv1 TLSv1.1 TLSv1.2"
+  ssl-redirect: "true"
+  upstream-fail-timeout: "5"
+  upstream-max-fails: "3"
+  use-gzip: "true"
+  use-http2: "false"
+  use-proxy-protocol: "true"
+  worker-processes: "auto"
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: ingress-nginx
+  namespace: ingress
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: nginx-ingress-controller
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ingress-nginx
+  namespace: ingress
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: ingress-nginx
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+---
+# Ingress controller deployment
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: ingress-nginx
+  namespace: ingress
+  labels:
+    k8s-app: nginx-ingress-controller
+    k8s-addon: ingress-nginx.addons.k8s.io
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+    metadata:
+      labels:
+        app: ingress-nginx
+        k8s-app: nginx-ingress-controller
+        k8s-addon: ingress-nginx.addons.k8s.io
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        duty: intake
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values:
+                - nginx-ingress-controller
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: nginx-ingress-controller
+      hostNetwork: true
+      initContainers:
+      - image: busybox:latest
+        imagePullPolicy: Always
+        name: sysctl-runner
+        securityContext:
+          privileged: true
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/sh
+          sysctl -w fs.file-max=65000
+          # Avoid a smurf attack
+          sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
+          # Turn on protection for bad icmp error messages
+          sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
+          # Turn on syncookies for SYN flood attack protection
+          sysctl -w net.ipv4.tcp_syncookies=1
+
+          # Turn on and log spoofed, source routed, and redirect packets
+          # sysctl -w net.ipv4.conf.all.log_martians = 1
+          # sysctl -w net.ipv4.conf.default.log_martians = 1
+          # # No source routed packets here
+          # sysctl -w net.ipv4.conf.all.accept_source_route = 0
+          # sysctl -w net.ipv4.conf.default.accept_source_route = 0
+          # # Turn on reverse path filtering
+          # sysctl -w net.ipv4.conf.all.rp_filter = 1
+          # sysctl -w net.ipv4.conf.default.rp_filter = 1
+          # # Make sure no one can alter the routing tables
+          # sysctl -w net.ipv4.conf.all.accept_redirects = 0
+          # net.ipv4.conf.default.accept_redirects = 0
+          # net.ipv4.conf.all.secure_redirects = 0
+          # net.ipv4.conf.default.secure_redirects = 0
+          # # Don't act as a router
+          # net.ipv4.ip_forward = 0
+          # net.ipv4.conf.all.send_redirects = 0
+          # net.ipv4.conf.default.send_redirects = 0
+          # # Turn on execshild
+          # kernel.exec-shield = 1
+          # kernel.randomize_va_space = 1
+
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+        name: nginx-ingress-controller
+        imagePullPolicy: Always
+        # Doesn't work with Calico before kops 1.8.0... we have to use host
+        # networking instead
+        # ports:
+        #   - name: http
+        #     containerPort: 80
+        #     hostPort: 80
+        #     protocol: TCP
+        #   - name: https
+        #     containerPort: 443
+        #     hostPort: 443
+        #     protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: 1000Mi
+          requests:
+            cpu: 400m
+            memory: 1000Mi
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-backend
+        - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller

--- a/aws/test/k8s/ingress/nginx-ingress-controller.yaml
+++ b/aws/test/k8s/ingress/nginx-ingress-controller.yaml
@@ -190,6 +190,30 @@ spec:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 70
 ---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress
+  labels:
+    k8s-app: nginx-ingress-controller
+  annotations:
+    # Enable PROXY protocol
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+    # Increase the ELB idle timeout to avoid issues with WebSockets or Server-Sent Events.
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
+spec:
+  type: LoadBalancer
+  selector:
+    k8s-app: nginx-ingress-controller
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+---
 # Ingress controller deployment
 kind: Deployment
 apiVersion: extensions/v1beta1
@@ -229,7 +253,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 60
       serviceAccountName: nginx-ingress-controller
-      hostNetwork: true
+      # hostNetwork: true
       initContainers:
       - image: busybox:latest
         imagePullPolicy: Always
@@ -275,17 +299,16 @@ spec:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
         name: nginx-ingress-controller
         imagePullPolicy: Always
-        # Doesn't work with Calico before kops 1.8.0... we have to use host
-        # networking instead
-        # ports:
-        #   - name: http
-        #     containerPort: 80
-        #     hostPort: 80
-        #     protocol: TCP
-        #   - name: https
-        #     containerPort: 443
-        #     hostPort: 443
-        #     protocol: TCP
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          - name: https
+            containerPort: 443
+            protocol: TCP
+          - name: health
+            containerPort: 10254
+            protocol: TCP
         readinessProbe:
           httpGet:
             path: /healthz

--- a/aws/test/k8s/kube-system/cluster-autoscaler.yaml
+++ b/aws/test/k8s/kube-system/cluster-autoscaler.yaml
@@ -1,0 +1,206 @@
+# Service account and roles
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - endpoints
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  resourceNames:
+  - cluster-autoscaler
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - services
+  - replicationcontrollers
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  - daemonsets
+  - deployments
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - watch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cluster-autoscaler-status
+  verbs:
+  - delete
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+
+# Actual cluster autoscaler deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      k8s-app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
+    spec:
+      serviceAccountName: cluster-autoscaler
+      nodeSelector:
+        duty: webserver
+      containers:
+        - name: cluster-autoscaler
+          image: gcr.io/google-containers/cluster-autoscaler:v0.6.2
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+          - ./cluster-autoscaler
+          - --cloud-provider=aws
+          - --scale-down-enabled=true
+          - --scale-down-delay=1m
+          - --scale-down-utilization-threshold=0.6
+          - --scale-down-unneeded-time=1m
+          - --scale-down-unready-time=6m
+          - --expander=least-waste
+          - --stderrthreshold=warning
+          - --v=4
+          - --skip-nodes-with-local-storage=false
+          # Per-ASG configuration
+          - --nodes=2:10:ingress.test.morpheo.io
+          - --nodes=2:15:default.test.morpheo.io
+          env:
+            - name: AWS_REGION
+              value: eu-west-1
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: "/etc/ssl/certs/ca-certificates.crt"
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-certificates.crt"
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule

--- a/aws/test/k8s/kube-system/critical-addons-rescheduler.yaml
+++ b/aws/test/k8s/kube-system/critical-addons-rescheduler.yaml
@@ -1,0 +1,91 @@
+# Service account and roles
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: rescheduler.addons.k8s.io
+    k8s-app: rescheduler
+  name: rescheduler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rescheduler
+  labels:
+    k8s-addon: rescheduler.addons.k8s.io
+    k8s-app: rescheduler
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: rescheduler
+  labels:
+    k8s-addon: rescheduler.addons.k8s.io
+    k8s-app: rescheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rescheduler
+subjects:
+  - kind: ServiceAccount
+    name: rescheduler
+    namespace: kube-system
+---
+# Rescheduler
+# The code is short and simple and can be found here, better than any doc :)
+# https://github.com/kubernetes/contrib/blob/master/rescheduler/rescheduler.go
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rescheduler
+  namespace: kube-system
+  labels:
+    app: rescheduler
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: rescheduler
+      kubernetes.io/cluster-service: "true"
+  template:
+    metadata:
+      name: rescheduler
+      namespace: kube-system
+      labels:
+        app: rescheduler
+        version: v0.3.1
+        kubernetes.io/cluster-service: "true"
+        kubernetes.io/name: "Rescheduler"
+    spec:
+      serviceAccountName: rescheduler
+      hostNetwork: true
+      containers:
+      - image: gcr.io/google_containers/rescheduler:v0.3.1
+        name: rescheduler
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        command:
+        - '/rescheduler'
+        args:
+        - '--running-in-cluster=true'
+      nodeSelector:
+        duty: webserver
+      restartPolicy: Always

--- a/aws/test/k8s/kube-system/dashboard.yaml
+++ b/aws/test/k8s/kube-system/dashboard.yaml
@@ -1,0 +1,77 @@
+# ServiceAccount & associated roles
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+# Actual service & deployment
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 9090
+  selector:
+    k8s-app: kubernetes-dashboard
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      nodeSelector:
+        duty: webserver
+      containers:
+      - name: kubernetes-dashboard
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule

--- a/aws/test/k8s/kube-system/heapster.yaml
+++ b/aws/test/k8s/kube-system/heapster.yaml
@@ -1,0 +1,158 @@
+# Service account & associated roles
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: heapster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system
+---
+# Heapster's pod_nanny monitors the heapster deployment & its pod(s), and scales
+# the resources of the deployment if necessary.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: system:pod-nanny
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: heapster-binding
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:pod-nanny
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system
+---
+
+# Actual service & deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Heapster"
+    kubernetes.io/cluster-service: "true"
+spec:
+  ports:
+    - port: 80
+      targetPort: 8082
+  selector:
+    k8s-app: heapster
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    k8s-addon: monitoring-standalone.addons.k8s.io
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    version: v1.7.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: heapster
+      version: v1.7.0
+  template:
+    metadata:
+      labels:
+        k8s-app: heapster
+        version: v1.7.0
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: heapster
+      nodeSelector:
+        duty: webserver
+      containers:
+        - image: gcr.io/google_containers/heapster:v1.4.0
+          name: heapster
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 5
+          resources:
+            # keep request = limit to keep this container in guaranteed class
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 300Mi
+          command:
+            - /heapster
+            - --source=kubernetes.summary_api:''
+        - image: gcr.io/google_containers/addon-resizer:2.0
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /pod_nanny
+            - --cpu=80m
+            - --extra-cpu=0.5m
+            - --memory=140Mi
+            - --extra-memory=4Mi
+            - --deployment=heapster
+            - --container=heapster
+            - --poll-period=300000
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"

--- a/aws/test/k8s/kube-system/kube-state-metrics.yaml
+++ b/aws/test/k8s/kube-system/kube-state-metrics.yaml
@@ -1,0 +1,159 @@
+# Access control lists
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+# Actual service and deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: gcr.io/google_containers/kube-state-metrics:v1.1.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 100m
+          limits:
+            memory: 200Mi
+            cpu: 200m
+      - name: addon-resizer
+        image: gcr.io/google_containers/addon-resizer:1.0
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/aws/test/k8s/kube-system/npd.yaml
+++ b/aws/test/k8s/kube-system/npd.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: npd-binding
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-problem-detector
+subjects:
+- kind: ServiceAccount
+  name: node-problem-detector
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: npd-v0.4.1
+  namespace: kube-system
+  labels:
+    k8s-app: node-problem-detector
+    version: v0.4.1
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: node-problem-detector
+        version: v0.4.1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: node-problem-detector
+        image: gcr.io/google_containers/node-problem-detector:v0.4.1
+        command:
+        - "/bin/sh"
+        - "-c"
+        # Pass both config to support both journald and syslog.
+        - "/node-problem-detector --logtostderr --system-log-monitors=/config/kernel-monitor.json,/config/kernel-monitor-filelog.json,/config/docker-monitor.json,/config/docker-monitor-filelog.json >>/var/log/node-problem-detector.log 2>&1"
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "100Mi"
+          requests:
+            cpu: "20m"
+            memory: "20Mi"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: log
+          mountPath: /var/log
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
+      volumes:
+      - name: log
+        hostPath:
+          path: /var/log/
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      serviceAccountName: node-problem-detector
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"

--- a/aws/test/k8s/namespaces.yaml
+++ b/aws/test/k8s/namespaces.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress

--- a/aws/test/provider.tf
+++ b/aws/test/provider.tf
@@ -1,0 +1,4 @@
+// Default AWS provider
+provider "aws" {
+  region = "eu-west-1"
+}

--- a/aws/test/test-cluster.tf
+++ b/aws/test/test-cluster.tf
@@ -1,0 +1,39 @@
+module "test-cluster" {
+  source = "./test-cluster"
+
+  aws-region = "${data.aws_region.main.name}"
+
+  kubernetes-version = "${var.kubernetes-version}"
+
+  # Networking
+  vpc-name                  = "karch-test-1"
+  vpc-number                = 0
+  availability-zones        = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  trusted-cidrs             = ["0.0.0.0/0"]
+  admin-ssh-public-key-path = "~/.ssh/terraform.pub"
+
+  # DNS
+  main-zone-id    = "${data.aws_route53_zone.test.id}"
+  cluster-name    = "test.${var.domain}"
+  kube-dns-domain = "cluster.karch-test-1"
+
+  # Kops & Kuberntetes
+  kops-state-bucket = "${var.kops-state-bucket}"
+  cloud-labels      = "${map("karch-test", "true")}"
+  base-ami          = "${data.aws_ami.coreos-stable.id}"
+
+  # Master
+  master-availability-zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  master-machine-type       = "m4.large"
+  master-volume-size        = "30"
+  master-volume-type        = "gp2"
+
+  # First minion instance group (HTTP webservers of all types + kube-system pods)
+  cluster-base-minion-ig-name      = "default"
+  cluster-base-minion-machine-type = "t2.medium"
+  cluster-base-minions-min         = 1
+  cluster-base-minions-max         = 15
+
+  # Ingress nodes
+  ingress-nodes-subnets = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/aws/test/test-cluster.tf
+++ b/aws/test/test-cluster.tf
@@ -31,7 +31,7 @@ module "test-cluster" {
   # First minion instance group (HTTP webservers of all types + kube-system pods)
   cluster-base-minion-ig-name      = "default"
   cluster-base-minion-machine-type = "t2.medium"
-  cluster-base-minions-min         = 1
+  cluster-base-minions-min         = 2
   cluster-base-minions-max         = 15
 
   # Ingress nodes

--- a/aws/test/test-cluster/ingress.tf
+++ b/aws/test/test-cluster/ingress.tf
@@ -1,0 +1,88 @@
+resource "aws_security_group" "ingress" {
+  name        = "https"
+  description = "[Managed by Terraform] Opens up ports 80, 443"
+  vpc_id      = "${module.kops-cluster.vpc-id}"
+
+  # HTTPs
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTP
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_elb" "ingress" {
+  cross_zone_load_balancing   = true
+  name                        = "ingress-${var.vpc-name}"
+  security_groups             = ["${aws_security_group.ingress.id}", "${module.kops-cluster.nodes-sg}"]
+  subnets                     = ["${module.kops-cluster.utility-subnets}"]
+  internal                    = false
+  idle_timeout                = 600
+  connection_draining         = "true"
+  connection_draining_timeout = "300"
+
+  listener {
+    instance_port     = 443
+    instance_protocol = "tcp"
+    lb_port           = 443
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "tcp"
+    lb_port           = 80
+    lb_protocol       = "tcp"
+  }
+
+  health_check {
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    timeout             = 5
+    target              = "TCP:80"
+    interval            = 10
+  }
+}
+
+# NOTE: with the new AWS network ELB, we shouldn't need that any more... should be investigated
+resource "aws_proxy_protocol_policy" "ingress" {
+  load_balancer  = "${aws_elb.ingress.name}"
+  instance_ports = ["80", "443"]
+}
+
+# And instances backing the pure TCP proxy protocoled ELB
+module "ingress-ig" {
+  source = "../../ig"
+
+  # Master cluster dependency hook
+  master-up = "${module.kops-cluster.master-up}"
+
+  # Global config
+  name              = "ingress"
+  cluster-name      = "${var.cluster-name}"
+  kops-state-bucket = "${var.kops-state-bucket}"
+  visibility        = "private"
+  subnets           = ["${var.ingress-nodes-subnets}"]
+  image             = "${var.base-ami}"
+  type              = "${var.ingress-machine-type}"
+  volume-size       = "30"
+  volume-type       = "gp2"
+  min-size          = "${var.ingress-min-nodes}"
+  max-size          = "${var.ingress-max-nodes}"
+  node-labels       = "${map("duty", "intake")}"
+}
+
+# Let's attach our instance group to the ingress ELB once it is created
+resource "aws_autoscaling_attachment" "ingress_lb_attachment" {
+  autoscaling_group_name = "${module.ingress-ig.asg-name}"
+  elb                    = "${aws_elb.ingress.id}"
+}

--- a/aws/test/test-cluster/ingress.tf
+++ b/aws/test/test-cluster/ingress.tf
@@ -1,65 +1,6 @@
-resource "aws_security_group" "ingress" {
-  name        = "https"
-  description = "[Managed by Terraform] Opens up ports 80, 443"
-  vpc_id      = "${module.kops-cluster.vpc-id}"
-
-  # HTTPs
-  ingress {
-    protocol    = "tcp"
-    from_port   = 443
-    to_port     = 443
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # HTTP
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-resource "aws_elb" "ingress" {
-  cross_zone_load_balancing   = true
-  name                        = "ingress-${var.vpc-name}"
-  security_groups             = ["${aws_security_group.ingress.id}", "${module.kops-cluster.nodes-sg}"]
-  subnets                     = ["${module.kops-cluster.utility-subnets}"]
-  internal                    = false
-  idle_timeout                = 600
-  connection_draining         = "true"
-  connection_draining_timeout = "300"
-
-  listener {
-    instance_port     = 443
-    instance_protocol = "tcp"
-    lb_port           = 443
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 80
-    instance_protocol = "tcp"
-    lb_port           = 80
-    lb_protocol       = "tcp"
-  }
-
-  health_check {
-    healthy_threshold   = 5
-    unhealthy_threshold = 2
-    timeout             = 5
-    target              = "TCP:80"
-    interval            = 10
-  }
-}
-
-# NOTE: with the new AWS network ELB, we shouldn't need that any more... should be investigated
-resource "aws_proxy_protocol_policy" "ingress" {
-  load_balancer  = "${aws_elb.ingress.name}"
-  instance_ports = ["80", "443"]
-}
-
-# And instances backing the pure TCP proxy protocoled ELB
+# Note: we should put the ingress controller on default nodes and deploy a single AZ database node group on which to
+# spawn statefulsets (maybe an EFK monitoring stack ?) so that we can check the successful creation of stateful sets and
+# - therefore - persistent volumes.
 module "ingress-ig" {
   source = "../../ig"
 
@@ -79,10 +20,4 @@ module "ingress-ig" {
   min-size          = "${var.ingress-min-nodes}"
   max-size          = "${var.ingress-max-nodes}"
   node-labels       = "${map("duty", "intake")}"
-}
-
-# Let's attach our instance group to the ingress ELB once it is created
-resource "aws_autoscaling_attachment" "ingress_lb_attachment" {
-  autoscaling_group_name = "${module.ingress-ig.asg-name}"
-  elb                    = "${aws_elb.ingress.id}"
 }

--- a/aws/test/test-cluster/kops-cluster.tf
+++ b/aws/test/test-cluster/kops-cluster.tf
@@ -21,7 +21,7 @@ module "kops-cluster" {
 
   # Kops & Kuberntetes
   kops-state-bucket  = "${var.kops-state-bucket}"
-  disable-sg-ingress = "true"
+  disable-sg-ingress = "false"
   channel            = "${var.kops-channel}"
   kubernetes-version = "${var.kubernetes-version}"
   cloud-labels       = "${var.cloud-labels}"

--- a/aws/test/test-cluster/kops-cluster.tf
+++ b/aws/test/test-cluster/kops-cluster.tf
@@ -1,0 +1,61 @@
+/*
+ * Cluster configuration
+ */
+module "kops-cluster" {
+  source = "../../cluster"
+
+  aws-region = "${var.aws-region}"
+
+  # Networking & connectivity
+  vpc-name                  = "${var.vpc-name}"
+  vpc-number                = "${var.vpc-number}"
+  availability-zones        = ["${var.availability-zones}"]
+  kops-topology             = "private"
+  trusted-cidrs             = "${var.trusted-cidrs}"
+  admin-ssh-public-key-path = "${var.admin-ssh-public-key-path}"
+
+  # DNS
+  main-zone-id    = "${var.main-zone-id}"
+  cluster-name    = "${var.cluster-name}"
+  kube-dns-domain = "${var.kube-dns-domain}"
+
+  # Kops & Kuberntetes
+  kops-state-bucket  = "${var.kops-state-bucket}"
+  disable-sg-ingress = "true"
+  channel            = "${var.kops-channel}"
+  kubernetes-version = "${var.kubernetes-version}"
+  cloud-labels       = "${var.cloud-labels}"
+  rbac               = "true"
+
+  # Kubelet/Container Runtime & system resource reservations
+  kube-reserved-cpu      = "100m"
+  system-reserved-cpu    = "100m"
+  kube-reserved-memory   = "256Mi"
+  system-reserved-memory = "256Mi"
+
+  # Master
+  master-availability-zones = ["${var.master-availability-zones}"]
+  master-lb-visibility      = "Public"
+  master-lb-idle-timeout    = "1200"
+  master-image              = "${var.base-ami}"
+  master-machine-type       = "${var.master-machine-type}"
+  master-volume-size        = "${var.master-volume-size}"
+  master-volume-type        = "${var.master-volume-type}"
+
+  # Bastion
+  bastion-image        = "${var.base-ami}"
+  bastion-machine-type = "t2.micro"
+  bastion-volume-size  = "10"
+  bastion-volume-type  = "gp2"
+
+  # First minion instance group
+  minion-ig-name      = "${var.cluster-base-minion-ig-name}"
+  minion-ig-public    = "false"
+  minion-image        = "${var.base-ami}"
+  minion-machine-type = "${var.cluster-base-minion-machine-type}"
+  minion-volume-size  = "30"
+  minion-volume-type  = "gp2"
+  min-minions         = "${var.cluster-base-minions-min}"
+  max-minions         = "${var.cluster-base-minions-max}"
+  minion-node-labels  = "${map("duty", "webserver")}"
+}

--- a/aws/test/test-cluster/outputs.tf
+++ b/aws/test/test-cluster/outputs.tf
@@ -1,0 +1,23 @@
+output "ingress-elb-dns-name" {
+  value = "${aws_elb.ingress.dns_name}"
+}
+
+output "ingress-elb-zone-id" {
+  value = "${aws_elb.ingress.zone_id}"
+}
+
+output "subnets" {
+  value = "${module.kops-cluster.subnets}"
+}
+
+output "nodes-sg" {
+  value = "${module.kops-cluster.nodes-sg}"
+}
+
+output "vpc-id" {
+  value = "${module.kops-cluster.vpc-id}"
+}
+
+output "master-up" {
+  value = "${module.kops-cluster.master-up}"
+}

--- a/aws/test/test-cluster/provider.tf
+++ b/aws/test/test-cluster/provider.tf
@@ -1,0 +1,8 @@
+/*
+ * AWS cloud provider & terraform user definition (spans the entire Morpheo Org.)
+ */
+
+// Default AWS provider, used for worldwide resources (IAM assets, main DNS zone...)
+provider "aws" {
+  region = "${var.aws-region}"
+}

--- a/aws/test/test-cluster/variables.tf
+++ b/aws/test/test-cluster/variables.tf
@@ -1,0 +1,164 @@
+# AWS provider config
+variable "aws-region" {
+  description = "The region to spawn this Kubernetes cluster into"
+  type        = "string"
+}
+
+# Networking & Security
+variable "vpc-name" {
+  description = "Arbitrary name to give to your VPC"
+  type        = "string"
+}
+
+variable "vpc-number" {
+  description = "The VPC number. This will define the VPC IP range in CIDR notation as follows: 10.<vpc_number>.0.0/16"
+  type        = "string"
+}
+
+variable "availability-zones" {
+  type        = "list"
+  description = "Availability zones to span (for HA master deployments, see master-availability-zones)"
+}
+
+variable "trusted-cidrs" {
+  type        = "list"
+  description = "CIDR whitelist for Kubernetes master HTTPs & bastion SSH access (default: 0.0.0.0/0)"
+
+  default = ["0.0.0.0/0"]
+}
+
+variable "admin-ssh-public-key-path" {
+  type        = "string"
+  description = "Path to the cluster admin's public SSH key (default: ~/.ssh/id_rsa.pub)"
+
+  default = "~/.ssh/id_rsa.pub"
+}
+
+## DNS
+variable "main-zone-id" {
+  description = "Route53 main zone ID"
+  type        = "string"
+}
+
+variable "cluster-name" {
+  description = "Cluster domain name (i.e. mycluster.example.com)"
+  type        = "string"
+}
+
+variable "kube-dns-domain" {
+  type        = "string"
+  description = "Domain enforced in our cluster by kube-dns (default: local, ex.: cluster.local)"
+}
+
+# Kops & Kubernetes
+variable "kops-state-bucket" {
+  type        = "string"
+  description = ""
+}
+
+variable "kops-channel" {
+  type        = "string"
+  description = "Channel to use for our Kops cluster (default stable)"
+  default     = "stable"
+}
+
+variable "kubernetes-version" {
+  type        = "string"
+  description = "Kubernetes version to use for Core components (default: v1.7.4)"
+  default     = "v1.7.4"
+}
+
+variable "cloud-labels" {
+  type        = "map"
+  description = "(Flat) map of kops cloud labels to apply to all resource in cluster"
+
+  default = {}
+}
+
+variable "base-ami" {
+  type        = "string"
+  description = "Base AMI ID to use for all of our nodes"
+}
+
+# Master instance group(s)
+variable "master-availability-zones" {
+  type        = "list"
+  description = "Availability zones in which to create master instance groups"
+}
+
+variable "master-machine-type" {
+  type        = "string"
+  description = "EC2 instance type to run our masters onto (default: m3.medium)"
+
+  default = "m4.large"
+}
+
+variable "master-volume-size" {
+  type        = "string"
+  description = "Size of our master's root volume, in GB (default: 10)"
+
+  default = "30"
+}
+
+variable "master-volume-type" {
+  type        = "string"
+  description = "Master volume type (io1/gp2), defaults to gp2"
+
+  default = "gp2"
+}
+
+# Initial minion instance group
+variable "cluster-base-minion-ig-name" {
+  type        = "string"
+  description = "Name to give to the ig created along with the cluster (default: default)"
+
+  default = "default"
+}
+
+variable "cluster-base-minion-machine-type" {
+  type        = "string"
+  description = "EC2 instance type to run our minions onto (default: t2.medium)"
+
+  default = "t2.medium"
+}
+
+variable "cluster-base-minions-min" {
+  type        = "string"
+  description = "Cluster base minion ASG min size (default: 1)"
+
+  default = 2
+}
+
+variable "cluster-base-minions-max" {
+  type        = "string"
+  description = "Cluster base minion ASG max size (default: 3)"
+
+  default = 3
+}
+
+# Hypothetical nodes targeted at welcoming our ingress controllers
+variable "ingress-nodes-subnets" {
+  type        = "list"
+  description = "Subnets (aka AZs) the ingress-nodes should span"
+}
+
+variable "ingress-machine-type" {
+  type        = "string"
+  description = "EC2 instance type to run our ingress nodes onto (default: t2.medium)"
+
+  default = "t2.medium"
+}
+
+variable "ingress-min-nodes" {
+  type        = "string"
+  description = "Ingress ASG min size (default: 1)"
+
+  default = 2
+}
+
+variable "ingress-max-nodes" {
+  type        = "string"
+  description = "Ingress ASG max size (default: 3)"
+
+  default = 3
+}

--- a/aws/test/variables.tf
+++ b/aws/test/variables.tf
@@ -1,0 +1,32 @@
+variable "aws-account-id" {
+  type        = "string"
+  description = "AWS account ID for your org."
+}
+
+variable "kops-policies" {
+  description = "IAM policies necessary for kops to work"
+  type        = "list"
+
+  default = [
+    "AmazonEC2FullAccess",
+    "AmazonRoute53FullAccess",
+    "AmazonS3FullAccess",
+    "IAMFullAccess",
+    "AmazonVPCFullAccess",
+  ]
+}
+
+variable "domain" {
+  type        = "string"
+  description = "Main domain name for the organization (ex.: example.com)"
+}
+
+variable "kops-state-bucket" {
+  description = "Name of the S3 bucket that will hold the Kops state files"
+  type        = "string"
+}
+
+variable "kubernetes-version" {
+  type        = "string"
+  description = "Kubernetes version to use for Core components (default: v1.7.4)"
+}


### PR DESCRIPTION
This PR makes it possible to spawn Kubernetes 1.8 clusters using Kops 1.8.

In addition we've added a test-cluster setup to test (manually for now) that the migration from 1.7 (Calico) to 1.8 (still using Calico) was effectively possible on CoreOS.

We'll soon use that test cluster to run automated tests against different distros/kubernetes versions/kops version/etcd version... In addition, testing upgrades (and downgrades ?) should also be handled.