### PR TITLE
Supporting Kops v1.10

### DIFF
--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -117,7 +117,6 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    # require-kubeconfig flag removed in 1.10 https://github.com/kubernetes/kops/pull/5621
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -117,6 +117,7 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
+    # require-kubeconfig flag removed in 1.10 https://github.com/kubernetes/kops/pull/5621
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -149,7 +149,6 @@ ${trusted-cidrs}
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    requireKubeconfig: true
   masterPublicName: api.${cluster-name}
   networkCIDR: ${vpc-cidr}
   networkID: ${vpc-id}

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -23,8 +23,8 @@ ${cloud-labels}
 ${etcd-clusters}
   keyStore: s3://${kops-state-bucket}/${cluster-name}/pki
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    insecureBindAddress: 127.0.0.1
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
@@ -117,7 +117,6 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    requireKubeconfig: true
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"


### PR DESCRIPTION
This PR will include necessary changes support Kops v1.10.

List of the included changes and Ref. (this list will be updated throughout the commits) :
- `admissionControl` has been replaced by `enableAdmissionControl` and `disableAdmissionControl` (mutually exclusive, order no longer matters) (Ref. https://github.com/kubernetes/kops/pull/5221)
- `requireKubeconfig` removed in v1.10 (Ref. https://github.com/kubernetes/kops/pull/5621)
- `address` (for specifiyinh inscecure address) replaced with `insecureBindAddress` (Ref. https://github.com/kubernetes/kops/pull/5234) 