### PR TITLE
Feature: configure wether or not to create multiple Nat Gateways

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -132,7 +132,7 @@ EOF
     public-cidr       = "${element(aws_subnet.utility.*.cidr_block, count.index)}"
     public-subnet-id  = "${element(aws_subnet.utility.*.id, count.index)}"
     private-subnet-id = "${element(aws_subnet.private.*.id, count.index)}"
-    nat-gateway-id    = "${element(var.multi-natgw == "true" ? 1 : aws_nat_gateway.natgw.*.id, count.index)}"
+    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
   }
 }
 

--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -132,7 +132,7 @@ EOF
     public-cidr       = "${element(aws_subnet.utility.*.cidr_block, count.index)}"
     public-subnet-id  = "${element(aws_subnet.utility.*.id, count.index)}"
     private-subnet-id = "${element(aws_subnet.private.*.id, count.index)}"
-    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
+    nat-gateway-id    = "${element(var.multi-natgw == "true" ? 1 : aws_nat_gateway.natgw.*.id, count.index)}"
   }
 }
 

--- a/aws/cluster/networking.tf
+++ b/aws/cluster/networking.tf
@@ -102,13 +102,13 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_eip" "nat-device" {
-  count = "${length(var.availability-zones)}"
+  count = "${var.multi-natgw != "true" ? 1 : length(var.availability-zones)}"
 
   vpc = true
 }
 
 resource "aws_nat_gateway" "natgw" {
-  count = "${length(var.availability-zones)}"
+  count = "${var.multi-natgw != "true" ? 1 : length(var.availability-zones)}"
 
   allocation_id = "${element(aws_eip.nat-device.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.utility.*.id, count.index)}"
@@ -130,7 +130,7 @@ resource "aws_route" "private-to-internet" {
 
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
+  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/aws/cluster/outputs.tf
+++ b/aws/cluster/outputs.tf
@@ -8,9 +8,9 @@ output "cluster-created" {
 }
 
 # DNS zone for the cluster subdomain
-output "cluster-zone-id" {
-  value = "${aws_route53_zone.cluster.id}"
-}
+# output "cluster-zone-id" {
+#   value = "${aws_route53_zone.cluster.id}"
+# }
 
 output "vpc-id" {
   value = "${aws_vpc.main.id}"

--- a/aws/cluster/route53.tf
+++ b/aws/cluster/route53.tf
@@ -10,7 +10,7 @@ resource "aws_route53_zone" "cluster" {
 }
 
 resource "aws_route53_record" "cluster-root" {
-  count = "${var.master-lb-visibility != "Private" && var.create-dns-zone == "true" ? 1 : 0}"
+  count = "${var.master-lb-visibility == "Public" && var.create-dns-zone == "true" ? 1 : 0}"
 
   zone_id = "${var.main-zone-id}"
   name    = "${var.cluster-name}"

--- a/aws/cluster/route53.tf
+++ b/aws/cluster/route53.tf
@@ -10,7 +10,7 @@ resource "aws_route53_zone" "cluster" {
 }
 
 resource "aws_route53_record" "cluster-root" {
-  count = "${var.master-lb-visibility == "Private" && var.create-dns-zone == "false" ? 0 : 1}"
+  count = "${var.master-lb-visibility != "Private" && var.create-dns-zone == "true" ? 1 : 0}"
 
   zone_id = "${var.main-zone-id}"
   name    = "${var.cluster-name}"

--- a/aws/cluster/route53.tf
+++ b/aws/cluster/route53.tf
@@ -3,13 +3,14 @@
  */
 
 resource "aws_route53_zone" "cluster" {
+  count         = "${var.create-dns-zone == "true" ? 1 : 0}"
   name          = "${var.cluster-name}"
   vpc_id        = "${var.master-lb-visibility == "Private" ? aws_vpc.main.id : ""}"
   force_destroy = true
 }
 
 resource "aws_route53_record" "cluster-root" {
-  count = "${var.master-lb-visibility == "Private" ? 0 : 1}"
+  count = "${var.master-lb-visibility == "Private" && var.create-dns-zone == "false" ? 0 : 1}"
 
   zone_id = "${var.main-zone-id}"
   name    = "${var.cluster-name}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -117,7 +117,6 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    # require-kubeconfig flag removed in 1.10 https://github.com/kubernetes/kops/pull/5621
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -117,6 +117,7 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
+    # require-kubeconfig flag removed in 1.10 https://github.com/kubernetes/kops/pull/5621
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -149,7 +149,6 @@ ${trusted-cidrs}
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    requireKubeconfig: true
   masterPublicName: api.${cluster-name}
   networkCIDR: ${vpc-cidr}
   networkID: ${vpc-id}

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -23,8 +23,8 @@ ${cloud-labels}
 ${etcd-clusters}
   keyStore: s3://${kops-state-bucket}/${cluster-name}/pki
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    insecureBindAddress: 127.0.0.1
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
@@ -117,7 +117,6 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    requireKubeconfig: true
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -19,6 +19,12 @@ variable "availability-zones" {
   description = "Availability zones to span (for HA master deployments, see master-availability-zones)"
 }
 
+variable "multi-natgw" {
+  type        = "string"
+  description = "Boolean that indicates wether or not to create NAT Gateway per Availability Zone (default: false)"
+  default     = "false"
+}
+
 variable "kops-topology" {
   type        = "string"
   description = "Kops topolopy (public|private), (default: private)"

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -21,8 +21,8 @@ variable "availability-zones" {
 
 variable "multi-natgw" {
   type        = "string"
-  description = "Boolean that indicates wether or not to create NAT Gateway per Availability Zone (default: false)"
-  default     = "false"
+  description = "Boolean that indicates wether or not to create NAT Gateway per Availability Zone (default: true)"
+  default     = "true"
 }
 
 variable "kops-topology" {

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -47,6 +47,13 @@ variable "main-zone-id" {
   default = ""
 }
 
+variable "create-dns-zone" {
+  description = "Route53 main zone ID (optional if the cluster zone is private)"
+  type        = "string"
+
+  default = "true"
+}
+
 variable "cluster-name" {
   description = "Cluster domain name (i.e. mycluster.example.com)"
   type        = "string"


### PR DESCRIPTION
Hello,

This will allow the usage of variable `multi-natgw` to configure wether or not to create a Nat Gateway per Availability Zone (the default behaviour).
This can be used to reduce the cost of testing environnement (such as staging).

Cheers
Mourad