### PR TITLE
Feature: configure wether or not to create multiple Nat Gateways

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -132,7 +132,7 @@ EOF
     public-cidr       = "${element(aws_subnet.utility.*.cidr_block, count.index)}"
     public-subnet-id  = "${element(aws_subnet.utility.*.id, count.index)}"
     private-subnet-id = "${element(aws_subnet.private.*.id, count.index)}"
-    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
+    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
   }
 }
 

--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -132,7 +132,7 @@ EOF
     public-cidr       = "${element(aws_subnet.utility.*.cidr_block, count.index)}"
     public-subnet-id  = "${element(aws_subnet.utility.*.id, count.index)}"
     private-subnet-id = "${element(aws_subnet.private.*.id, count.index)}"
-    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
+    nat-gateway-id    = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 0 : count.index)}"
   }
 }
 

--- a/aws/cluster/networking.tf
+++ b/aws/cluster/networking.tf
@@ -102,13 +102,13 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_eip" "nat-device" {
-  count = "${length(var.availability-zones)}"
+  count = "${var.multi-natgw != "true" ? 1 : length(var.availability-zones)}"
 
   vpc = true
 }
 
 resource "aws_nat_gateway" "natgw" {
-  count = "${length(var.availability-zones)}"
+  count = "${var.multi-natgw != "true" ? 1 : length(var.availability-zones)}"
 
   allocation_id = "${element(aws_eip.nat-device.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.utility.*.id, count.index)}"
@@ -130,7 +130,7 @@ resource "aws_route" "private-to-internet" {
 
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
+  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/aws/cluster/networking.tf
+++ b/aws/cluster/networking.tf
@@ -130,7 +130,7 @@ resource "aws_route" "private-to-internet" {
 
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 1 : count.index)}"
+  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, var.multi-natgw != "true" ? 0 : count.index)}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -23,8 +23,8 @@ ${cloud-labels}
 ${etcd-clusters}
   keyStore: s3://${kops-state-bucket}/${cluster-name}/pki
   kubeAPIServer:
-    insecureBindAddress: 127.0.0.1
-    enableAdmissionPlugins:
+    address: 127.0.0.1
+    admissionControl:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
@@ -117,6 +117,7 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
+    requireKubeconfig: true
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -23,8 +23,8 @@ ${cloud-labels}
 ${etcd-clusters}
   keyStore: s3://${kops-state-bucket}/${cluster-name}/pki
   kubeAPIServer:
-    address: 127.0.0.1
-    admissionControl:
+    insecureBindAddress: 127.0.0.1
+    enableAdmissionPlugins:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
@@ -117,7 +117,6 @@ ${apiserver-runtime-config}
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: gcr.io/google_containers/pause-amd64:3.0
     podManifestPath: /etc/kubernetes/manifests
-    requireKubeconfig: true
     kubeReserved:
       cpu: "${kube-reserved-cpu}"
       memory: "${kube-reserved-memory}"

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -19,6 +19,12 @@ variable "availability-zones" {
   description = "Availability zones to span (for HA master deployments, see master-availability-zones)"
 }
 
+variable "multi-natgw" {
+  type        = "string"
+  description = "Boolean that indicates wether or not to create NAT Gateway per Availability Zone (default: true)"
+  default     = "true"
+}
+
 variable "kops-topology" {
   type        = "string"
   description = "Kops topolopy (public|private), (default: private)"


### PR DESCRIPTION
Hello,

This will allow the usage of variable `multi-natgw` to configure wether or not to create a Nat Gateway per Availability Zone (the default behaviour).
This can be used to reduce the cost of testing environnement (such as staging).

Cheers
Mourad